### PR TITLE
Update 03-kube-intro.adoc

### DIFF
--- a/documentation/modules/ROOT/pages/03-kube-intro.adoc
+++ b/documentation/modules/ROOT/pages/03-kube-intro.adoc
@@ -396,7 +396,7 @@ myapp   myapp-asotobue-dev.apps.sandbox.x8i5.p1.openshiftapps.com          myapp
 [.console-input]
 [source, bash]
 ----
-curl myapp-asotobue-dev.apps.sandbox.x8i5.p1.openshiftapps.com:8080
+curl myapp-asotobue-dev.apps.sandbox.x8i5.p1.openshiftapps.com
 ----
 
 ====


### PR DESCRIPTION
You don't add the port when you curl the route.  It's already mapped.  Using port 8080 will just cause it to spin